### PR TITLE
FEATURE: Add remaining button variants

### DIFF
--- a/Resources/Private/Fusion/Components/Button.fusion
+++ b/Resources/Private/Fusion/Components/Button.fusion
@@ -55,6 +55,8 @@ prototype(NeosBE:Button) < prototype(Neos.Fusion:Component) {
     # If set to `true` the button is highlighted as a dangerous button (usually with orange/red colors)
     isDangerous = false
 
+    # If set to `true` the button is highlighted as a success button (usually with green color)
+    isSuccess = false
 
     # If set, the button will link to the specified module (e.g. "administration/users"). This can be combined with  `action`, `arguments` and `addQueryString`
     module = ''
@@ -78,7 +80,7 @@ prototype(NeosBE:Button) < prototype(Neos.Fusion:Component) {
     modal = ''
 
     renderer.@context {
-        class = ${'neos-button' + (props.isPrimary ? ' neos-button-primary' : '') + (props.isDangerous ? ' neos-button-danger' : '')}
+        class = ${'neos-button' + (props.isPrimary ? ' neos-button-primary' : '') + (props.isDangerous ? ' neos-button-danger' : '') + (props.isSuccess ? ' neos-button-success' : '')}
         content = Neos.Fusion:Case {
             withIcon {
                 condition = ${!String.isBlank(props.icon)}

--- a/Resources/Private/Fusion/Components/Button.fusion
+++ b/Resources/Private/Fusion/Components/Button.fusion
@@ -58,6 +58,9 @@ prototype(NeosBE:Button) < prototype(Neos.Fusion:Component) {
     # If set to `true` the button is highlighted as a success button (usually with green color)
     isSuccess = false
 
+    # If set to `true` the button is highlighted as a warning button (usually with yellow color)
+    isWarning = false
+
     # If set, the button will link to the specified module (e.g. "administration/users"). This can be combined with  `action`, `arguments` and `addQueryString`
     module = ''
 
@@ -80,7 +83,7 @@ prototype(NeosBE:Button) < prototype(Neos.Fusion:Component) {
     modal = ''
 
     renderer.@context {
-        class = ${'neos-button' + (props.isPrimary ? ' neos-button-primary' : '') + (props.isDangerous ? ' neos-button-danger' : '') + (props.isSuccess ? ' neos-button-success' : '')}
+        class = ${'neos-button' + (props.isPrimary ? ' neos-button-primary' : '') + (props.isDangerous ? ' neos-button-danger' : '') + (props.isSuccess ? ' neos-button-success' : '') + (props.isWarning ? ' neos-button-warning' : '')}
         content = Neos.Fusion:Case {
             withIcon {
                 condition = ${!String.isBlank(props.icon)}

--- a/Resources/Private/Fusion/Components/Button.fusion
+++ b/Resources/Private/Fusion/Components/Button.fusion
@@ -83,7 +83,13 @@ prototype(NeosBE:Button) < prototype(Neos.Fusion:Component) {
     modal = ''
 
     renderer.@context {
-        class = ${'neos-button' + (props.isPrimary ? ' neos-button-primary' : '') + (props.isDangerous ? ' neos-button-danger' : '') + (props.isSuccess ? ' neos-button-success' : '') + (props.isWarning ? ' neos-button-warning' : '')}
+        class = ${[
+            'neos-button',
+            props.isPrimary && 'neos-button-primary',
+            props.isDangerous && 'neos-button-danger',
+            props.isSuccess && 'neos-button-success',
+            props.isWarning && 'neos-button-warning'
+        ]}
         content = Neos.Fusion:Case {
             withIcon {
                 condition = ${!String.isBlank(props.icon)}


### PR DESCRIPTION
This PR adds the remaining button variants `success` and `warning` as defined in the backend stylesheet provided by `Neos.Neos`. These variants can be applied thusly:

```neosfusion
<NeosBE:Button isSuccess>A button indicating success</NeosBE:Button>
<NeosBE:Button isWarning>A button indicating something's wrong, but not so wrong it could be considered dangerous.</NeosBE:Button>
```

API follows the path set out by the `isPrimary` and `isDangerous` props.

I also refactored the assembly of the `class`-attribute of the Button component, to improve readability after that line had grown much too large.